### PR TITLE
Switch to sync.RWMutex

### DIFF
--- a/htgroup.go
+++ b/htgroup.go
@@ -26,7 +26,7 @@ type userGroupMap map[string][]string
 // A HTGroup encompasses an Apache-style group file.
 type HTGroup struct {
 	filePath   string
-	mutex      sync.Mutex
+	mutex      sync.RWMutex
 	userGroups userGroupMap
 }
 
@@ -123,9 +123,9 @@ func (htGroup *HTGroup) IsUserInGroup(user string, group string) bool {
 // GetUserGroups reads all groups of a user.
 // Returns all groups as a string array or an empty array.
 func (htGroup *HTGroup) GetUserGroups(user string) []string {
-	htGroup.mutex.Lock()
+	htGroup.mutex.RLock()
 	groups := htGroup.userGroups[user]
-	htGroup.mutex.Unlock()
+	htGroup.mutex.RUnlock()
 
 	if groups == nil {
 		return []string{}

--- a/htpasswd.go
+++ b/htpasswd.go
@@ -53,7 +53,7 @@ type BadLineHandler func(err error)
 // An File encompasses an Apache-style htpasswd file for HTTP Basic authentication
 type File struct {
 	filePath string
-	mutex    sync.Mutex
+	mutex    sync.RWMutex
 	passwds  passwdTable
 	parsers  []PasswdParser
 }
@@ -104,9 +104,9 @@ func NewFromReader(r io.Reader, parsers []PasswdParser, bad BadLineHandler) (*Fi
 // Match checks the username and password combination to see if it represents
 // a valid account from the htpassword file.
 func (bf *File) Match(username, password string) bool {
-	bf.mutex.Lock()
+	bf.mutex.RLock()
 	matcher, ok := bf.passwds[username]
-	bf.mutex.Unlock()
+	bf.mutex.RUnlock()
 
 	if ok && matcher.MatchesPassword(password) {
 		// we are good


### PR DESCRIPTION
In order to allow atomic reloads for passwd and group files this libraries uses mutexes to prevent lookups during reloads. In the current form this also means that concurrent lookups are not possible. This change replaces sync.Mutex with sync.RWMutex which allows concurrent read access.